### PR TITLE
Extended built-in grid converter

### DIFF
--- a/src/Skybrud.Umbraco.GridData.LeBlender/Converters/LeBlenderGridConverter.cs
+++ b/src/Skybrud.Umbraco.GridData.LeBlender/Converters/LeBlenderGridConverter.cs
@@ -1,58 +1,105 @@
-﻿using Newtonsoft.Json.Linq;
+using System;
+using Newtonsoft.Json.Linq;
 using Skybrud.Umbraco.GridData.Interfaces;
 using Skybrud.Umbraco.GridData.LeBlender.Config;
 using Skybrud.Umbraco.GridData.LeBlender.Values;
 using Skybrud.Umbraco.GridData.Rendering;
 
-namespace Skybrud.Umbraco.GridData.LeBlender.Converters {
-    
-    public class LeBlenderGridConverter : IGridConverter {
+namespace Skybrud.Umbraco.GridData.LeBlender.Converters
+{
+    public class LeBlenderGridConverter : IGridConverter
+    {
+        /// <summary>
+        /// The function that checks whether the editor is an LeBlender editor.
+        /// </summary>
+        private readonly Func<GridEditor, bool> isLeBlenderEditor;
 
         /// <summary>
-        /// Converts the specified <paramref name="token"/> into an instance of <see cref="IGridControlValue"/>.
+        /// Initializes a new instance of the <see cref="LeBlenderGridConverter" /> class.
         /// </summary>
-        /// <param name="control">A reference to the parent <see cref="GridControl"/>.</param>
-        /// <param name="token">The instance of <see cref="JToken"/> representing the control value.</param>
+        public LeBlenderGridConverter()
+            : this(IsLeBlenderEditor)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeBlenderGridConverter" /> class.
+        /// </summary>
+        /// <param name="isLeBlenderEditor">The function that checks whether the editor is an LeBlender editor.</param>
+        /// <exception cref="ArgumentNullException">isLeBlenderEditor</exception>
+        public LeBlenderGridConverter(Func<GridEditor, bool> isLeBlenderEditor)
+        {
+            if (isLeBlenderEditor == null) throw new ArgumentNullException(nameof(isLeBlenderEditor));
+
+            this.isLeBlenderEditor = isLeBlenderEditor;
+        }
+
+        /// <summary>
+        /// Converts the specified <paramref name="token" /> into an instance of <see cref="IGridControlValue" />.
+        /// </summary>
+        /// <param name="control">A reference to the parent <see cref="GridControl" />.</param>
+        /// <param name="token">The instance of <see cref="JToken" /> representing the control value.</param>
         /// <param name="value">The converted control value.</param>
-        public bool ConvertControlValue(GridControl control, JToken token, out IGridControlValue value) {
+        /// <returns></returns>
+        public bool ConvertControlValue(GridControl control, JToken token, out IGridControlValue value)
+        {
             value = null;
-            if (IsLeBlenderEditor(control.Editor)) {
+            if (this.isLeBlenderEditor(control.Editor))
+            {
                 value = GridControlLeBlenderValue.Parse(control);
             }
+
             return value != null;
         }
 
         /// <summary>
-        /// Converts the specified <paramref name="token"/> into an instance of <see cref="IGridEditorConfig"/>.
+        /// Converts the specified <paramref name="token" /> into an instance of <see cref="IGridEditorConfig" />.
         /// </summary>
         /// <param name="editor"></param>
-        /// <param name="token">The instance of <see cref="JToken"/> representing the editor config.</param>
+        /// <param name="token">The instance of <see cref="JToken" /> representing the editor config.</param>
         /// <param name="config">The converted editor config.</param>
-        public bool ConvertEditorConfig(GridEditor editor, JToken token, out IGridEditorConfig config) {
+        /// <returns></returns>
+        public bool ConvertEditorConfig(GridEditor editor, JToken token, out IGridEditorConfig config)
+        {
             config = null;
-            if (IsLeBlenderEditor(editor)) {
+            if (this.isLeBlenderEditor(editor))
+            {
                 config = GridEditorLeBlenderConfig.Parse(editor, token as JObject);
             }
+
             return config != null;
         }
 
         /// <summary>
-        /// Gets an instance <see cref="GridControlWrapper"/> for the specified <paramref name="control"/>.
+        /// Gets an instance <see cref="GridControlWrapper" /> for the specified <paramref name="control" />.
         /// </summary>
         /// <param name="control">The control to be wrapped.</param>
         /// <param name="wrapper">The wrapper.</param>
-        public bool GetControlWrapper(GridControl control, out GridControlWrapper wrapper) {
+        /// <returns></returns>
+        public bool GetControlWrapper(GridControl control, out GridControlWrapper wrapper)
+        {
             wrapper = null;
-            if (IsLeBlenderEditor(control.Editor)) {
+            if (this.isLeBlenderEditor(control.Editor))
+            {
                 wrapper = control.GetControlWrapper<GridControlLeBlenderValue, GridEditorLeBlenderConfig>();
             }
+
             return wrapper != null;
         }
 
-        private bool IsLeBlenderEditor(GridEditor editor) {
-            return editor.Alias.ToLower().StartsWith("leblender.");
+        /// <summary>
+        /// Determines whether the <paramref name="editor" /> is an LeBlender editor.
+        /// </summary>
+        /// <param name="editor">The editor.</param>
+        /// <returns>
+        ///   <c>true</c> if the <paramref name="editor" /> is an LeBlender editor; otherwise, <c>false</c>.
+        /// </returns>
+        /// <remarks>
+        /// Checks whether the view starts with '/App_Plugins/LeBlender/' or the alias starts with 'LeBlender.'.
+        /// </remarks>
+        private static bool IsLeBlenderEditor(GridEditor editor)
+        {
+            return editor.View.StartsWith("/App_Plugins/LeBlender/", StringComparison.OrdinalIgnoreCase) ||
+                editor.Alias.StartsWith("LeBlender.", StringComparison.OrdinalIgnoreCase); // Kept for backwards compatibility
         }
-    
     }
-
 }


### PR DESCRIPTION
Added extensibility points for supplying a custom checking function (without duplicating the whole class) and extended default check to include `View` path (also using correct `StartsWith` overload for case insensitive comparison). Fixes issue #1.